### PR TITLE
Change velocity using a force

### DIFF
--- a/ControllerScript
+++ b/ControllerScript
@@ -139,7 +139,8 @@ public class Controller : MonoBehaviour
         //This is stored in a temp vec3
         Vector3 targetDirectionMovement = desiredRotation * Vector3.up;
         Vector3 heading = Vector3.SmoothDamp(transform.up, targetDirectionMovement, ref velocitySmoothDampForPlayerVelocity, SmoothDampTime);
-        _rigidBody.velocity = heading * storedSpeed * Time.deltaTime;
+        Vector3 desiredVelocity = heading * storedSpeed * Time.deltaTime;
+        _rigidBody.AddForce((desiredVelocity - _rigidBody.velocity), ForceMode.VelocityChange);
 
     }
     private void SlopeAdjustments()


### PR DESCRIPTION
This adds one extra line which replacing setting the velocity directly with the force required to get to the desired velocity. This can be more stable and organic than setting the velocity directly especially if your character is bumping into or pushing around other geometry. The behavior should hopefully be indistinguishable from what you had previously.